### PR TITLE
Working in ruby2

### DIFF
--- a/lib/postcodeanywhere.rb
+++ b/lib/postcodeanywhere.rb
@@ -52,9 +52,9 @@ module PostcodeAnywhere
         @address_lookup.address_line_2 = formatted_data["line2"]
         @address_lookup.address_line_3 = formatted_data["line3"]
         @address_lookup.post_town = formatted_data["post_town"]
-        @address_lookup.county = formatted_data["county"].blank? ? formatted_data["post_town"] : formatted_data["county"]
+        @address_lookup.county = formatted_data["county"].empty? ? formatted_data["post_town"] : formatted_data["county"]
       elsif self.country_code == 'US'
-        @address_lookup.postcode = formatted_data["zip4"].blank? ? @postcode_search.postcode : formatted_data["zip4"]
+        @address_lookup.postcode = formatted_data["zip4"].empty? ? @postcode_search.postcode : formatted_data["zip4"]
         @address_lookup.address_line_1 = formatted_data["line1"]
         @address_lookup.address_line_2 = formatted_data["line2"]
         @address_lookup.address_line_3 = formatted_data["line3"]

--- a/test/test_postcodeanywhere.rb
+++ b/test/test_postcodeanywhere.rb
@@ -1,7 +1,26 @@
 require 'helper'
 
 class TestPostcodeanywhere < Test::Unit::TestCase
-  should "probably rename this file and start testing for real" do
-    flunk "hey buddy, you should probably rename this file and start testing for real"
+
+  def setup
+    flunk "You gotta provide some postcode anywhere account details details (see test)" unless ENV['TEST_PCA_ACCOUNT'] && ENV['TEST_PCA_LICENSE']
+    PostcodeAnywhere::Request.account_code = ENV['TEST_PCA_ACCOUNT']
+    PostcodeAnywhere::Request.license_code = ENV['TEST_PCA_LICENSE']
   end
+
+  def test_we_are_in_ruby2
+    assert_match /^2/, RUBY_VERSION
+  end
+
+  def test_lookup # does lookup work?
+    res = PostcodeAnywhere::PostcodeSearch.new(:country_code=> 'GB', :postcode => 'MK5 8FT').lookup
+    assert_kind_of Array, res
+  end
+
+  def test_fetch # does fetch work?
+    res = PostcodeAnywhere::PostcodeSearch.new(:country_code=> 'GB', :fetch_id => '50737583.00').fetch
+    assert_kind_of PostcodeAnywhere::AddressLookup, res
+  end
+
 end
+


### PR DESCRIPTION
Hello,
I recently used this gem to get some stuff out from PostcodeAnywhere ... I noticed it does not work in Ruby2  .. this tiny update replaced "blank?" with "empty?" (as blank? is no longer in Ruby)
Sorry the test update is teeny tiny, as is just to ensure the ruby version is 2 and the two key class methods still work..
